### PR TITLE
Update Bonjour Makefile

### DIFF
--- a/Bonjour/Makefile
+++ b/Bonjour/Makefile
@@ -14,5 +14,6 @@ objects = \
 target         = PocoDNSSDBonjour
 target_version = 1
 target_libs    = PocoNet PocoDNSSD PocoFoundation
+INCLUDE       += -I../include/
 
 include $(POCO_BASE)/build/rules/lib


### PR DESCRIPTION
Previously, `make` would face an error as Bonjour.h could not find `'Poco/DNSSD/DNSSD.h'`. This error is rectified by including the include folder of DNSSD into the makefile.